### PR TITLE
Strucutral Issue with GC Content being on Fasta

### DIFF
--- a/Base/Algorithms/MajorityElement.cs
+++ b/Base/Algorithms/MajorityElement.cs
@@ -6,7 +6,6 @@ public class MajorityElement<T>
     ///     Returns the majority element of an array if it exists.
     ///     Otherwise returns null. It is upon the caller to post process the default value
     ///     Kind of a failed experiment with value types.
-    ///     // TODO: as an exercise consider how to do this with reference types.
     /// </summary>
     /// <param name="values"></param>
     /// <returns></returns>
@@ -32,15 +31,7 @@ public class MajorityElement<T>
 
         return default;
     }
-
-    /// <summary>
-    ///     Returns the majority element of an array if it exists.
-    ///     Otherwise returns null. It is upon the caller to post process the default value
-    ///     Kind of a failed experiment with value types.
-    ///     // TODO: as an exercise consider how to do this with reference types.
-    /// </summary>
-    /// <param name="values"></param>
-    /// <returns></returns>
+    
     public static T? SimpleDictionary(List<T> values)
     {
         var tracker = new Dictionary<T, int>();

--- a/Base/Algorithms/Search.cs
+++ b/Base/Algorithms/Search.cs
@@ -6,15 +6,12 @@ public static class Search
 {
     public static List<List<int>> ThreeSumNoSort(List<int> inputArray, int target)
     {
-        // Use a HashSet to store unique triplets (sorting each triplet ensures uniqueness regardless of order)
         var result = new HashSet<List<int>>(ListEqualityComparer<int>.Default);
 
         for (var i = 0; i < inputArray.Count - 2; i++)
         {
-            // Use a secondary HashSet inside the loop to track numbers seen so far for the current 'i'
             var seen = new Dictionary<int, int>();
-            var targetSum = -inputArray[i]; // Target for the remaining two numbers
-
+            var targetSum = -inputArray[i]; 
             for (var j = i + 1; j < inputArray.Count; j++)
             {
                 var needed = targetSum - inputArray[j];
@@ -26,8 +23,7 @@ public static class Search
                     triplet.Sort(); // Sort the triplet to handle duplicates in the result set
                     result.Add(triplet);
                 }
-
-                // Add the current number to the 'seen' set for future checks
+                
                 // TODO: this is restrictive. It should work for duplicates
                 if (!seen.ContainsKey(inputArray[j]))
                     seen.Add(inputArray[j], j);

--- a/Base/DataStructures/AlignmentMatrix.cs
+++ b/Base/DataStructures/AlignmentMatrix.cs
@@ -97,7 +97,6 @@ public class AlignmentMatrix : IAlignmentMatrix
         return new AlignmentMatrix(a, b).LongestCommonSubSequence();
     }
 
-    // TODO: I think this should be held as an external object as things get more abstracted.
     private class Node
     {
         public Node()

--- a/Base/DataStructures/BasePairDictionary.cs
+++ b/Base/DataStructures/BasePairDictionary.cs
@@ -6,7 +6,6 @@ namespace Base.DataStructures;
 /// <summary>
 ///     A basic counter for the total number of base pairs on a given sequence.
 ///     Also tracks total number of bps in the class
-///     TODO: this should just be a character dictionary which extends into a basepair dictionary for RNA and DNA
 ///     and a protein dictionary for others
 /// </summary>
 public class BasePairDictionary : IBasePairDictionary
@@ -14,7 +13,6 @@ public class BasePairDictionary : IBasePairDictionary
     private readonly Dictionary<char, long> _dictionary = new();
     public long Count { get; private set; }
 
-    // This is a very, very optimistic implementation. This only works for addonly. Worry about it if we get to an edit case
     public char HighestFrequencyBasePair { get; private set; }
     public long HighestFrequencyBasePairCount { get; private set; }
 

--- a/Bio/IO/Fasta.cs
+++ b/Bio/IO/Fasta.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Base.DataStructures;
 using Bio.Sequences;
+using Bio.Sequences.Types;
 
 namespace Bio.IO;
 
@@ -32,18 +33,7 @@ public class Fasta : IFasta
         ContentType = isPossibleRNA ? ContentType.RNA : ContentType.DNA;
     }
 
-    // TODO: consider moving this to a nucleotide class. Or maybe a generic 
-    public double GCContent
-    {
-        get
-        {
-            // TODO: this is a hack that can get refactored. I need to determine if I can safely assume that everything can be converted to uppercase
-            var totalGC = BasePairDictionary.GetFrequency('G') + BasePairDictionary.GetFrequency('g') +
-                          BasePairDictionary.GetFrequency('C') + BasePairDictionary.GetFrequency('c');
-            var totalBp = BasePairDictionary.Count;
-            return (double)totalGC / totalBp;
-        }
-    }
+   
 
     public ContentType ContentType { get; }
 
@@ -97,7 +87,6 @@ public class Fasta : IFasta
         }
     }
 
-    // TODO: this is rife for errors down the line
     public override bool Equals(object? obj)
     {
         try
@@ -115,7 +104,7 @@ public class Fasta : IFasta
 
     public static Fasta GetMaxGCContent(IList<Fasta> fastas)
     {
-        return fastas.Aggregate((i1, i2) => i1.GCContent > i2.GCContent ? i1 : i2);
+        return fastas.Aggregate((i1, i2) => new DnaSequence(i1.RawSequence).GCRatio() > new DnaSequence(i2.RawSequence).GCRatio() ? i1 : i2);
     }
 
     public override int GetHashCode()

--- a/Bio/Sequences/Interfaces/INucleotideSequence.cs
+++ b/Bio/Sequences/Interfaces/INucleotideSequence.cs
@@ -11,4 +11,10 @@ public interface INucleotideSequence
     int[] CalculateMinPrefixGCSkew();
 
     double TransitionToTransversionRatio(NucleotideSequence other);
+
+    /// <summary>
+    /// Returns the ratio of the GC content in 
+    /// </summary>
+    /// <returns></returns>
+    double GCRatio();
 }

--- a/Bio/Sequences/Types/DnaSequence.cs
+++ b/Bio/Sequences/Types/DnaSequence.cs
@@ -62,7 +62,6 @@ public class DnaSequence(string rawSequence) : NucleotideSequence(rawSequence), 
         for (var i = 0; i < Length; i++)
         {
             var j = 4;
-            // TODO: verify these
             while (i + j <= Length && j <= 12)
             {
                 var subStringDNA = new DnaSequence(Substring(i, j));

--- a/Bio/Sequences/Types/DnaSequenceListExtensions.cs
+++ b/Bio/Sequences/Types/DnaSequenceListExtensions.cs
@@ -26,7 +26,6 @@ namespace Bio.Sequences.Types;
 ///     In basically 3 hours, 'solved' a lot of problems. I'm not sure I understand it much better compared to when
 ///     I started. I have gists, not deep knowledge.
 /// </remarks>
-/// .
 public static class DnaSequenceListExtensions
 {
     private static readonly Dictionary<char, int> NucleotideToIndex = new()

--- a/Bio/Sequences/Types/NucleotideSequence.cs
+++ b/Bio/Sequences/Types/NucleotideSequence.cs
@@ -75,4 +75,13 @@ public abstract class NucleotideSequence : Sequence, INucleotideSequence
 
         return (double)transitions / transversions;
     }
+
+    public double GCRatio()
+    {
+        var totalGC = Counts.GetFrequency('G') + Counts.GetFrequency('g') +
+                      Counts.GetFrequency('C') + Counts.GetFrequency('c');
+        var totalBp = Counts.Count;
+        return (double)totalGC / totalBp;
+    }
+
 }

--- a/BioTests/IO/FastaTests.cs
+++ b/BioTests/IO/FastaTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bio.IO;
 using Bio.Sequences;
+using Bio.Sequences.Types;
 using BioMath;
 
 namespace BioTests.IO;
@@ -77,7 +78,7 @@ public class FastaTests
     public void FastaGCContent()
     {
         var someFasta = new Fasta(SomeName, SomeIllegitimateDNASequence);
-        Assert.IsTrue(Helpers.DoublesEqualWithinRange(someFasta.GCContent, 0.4285));
+        Assert.IsTrue(Helpers.DoublesEqualWithinRange(new DnaSequence(someFasta.RawSequence).GCRatio(), 0.4285));
     }
 
     [TestMethod]
@@ -85,6 +86,6 @@ public class FastaTests
     {
         var fastas = FastaParser.Read(_multipleFastaPath);
         var highest = Fasta.GetMaxGCContent(fastas);
-        Assert.IsTrue(Helpers.DoublesEqualWithinRange(60.919540, highest.GCContent * 100));
+        Assert.IsTrue(Helpers.DoublesEqualWithinRange(60.919540, new DnaSequence(highest.RawSequence).GCRatio() * 100));
     }
 }

--- a/BioTests/Sequence/TestData/crab1.fasta
+++ b/BioTests/Sequence/TestData/crab1.fasta
@@ -1,1 +1,1 @@
-{"GCContent":0.42857142857142855,"ContentType":1,"Name":"some Name","RawSequence":"aaccttg","BasePairDictionary":{"Count":7,"HighestFrequencyBasePair":"a","HighestFrequencyBasePairCount":2},"Length":7}
+{"ContentType":1,"Name":"some Name","RawSequence":"aaccttg","BasePairDictionary":{"Count":7,"HighestFrequencyBasePair":"a","HighestFrequencyBasePairCount":2},"Length":7}

--- a/DNAStore/InputProcessor.cs
+++ b/DNAStore/InputProcessor.cs
@@ -888,26 +888,7 @@ internal static class InputProcessor
         {
         }
     }
-
-    private class GCContent : BaseExecutor
-    {
-        private IList<Fasta>? fastas;
-        private Fasta? largestGCContent;
-
-        protected override void GetInputs()
-        {
-            Console.WriteLine("Please input path to file");
-            var location = Console.ReadLine();
-            if (location != null) fastas = FastaParser.Read(location);
-        }
-
-        protected override void CalculateResult()
-        {
-            largestGCContent = fastas?.Aggregate((i1, i2) => i1.GCContent > i2.GCContent ? i1 : i2);
-            Output = string.Format($"{largestGCContent?.Name}\n{largestGCContent?.GCContent * 100}");
-        }
-    }
-
+    
     private class RandomStringProbability : BaseExecutor
     {
         private List<double> gcPercentages;


### PR DESCRIPTION
Realistically, the Fasta object can hold a protein. It should be completely agnostic of what it holds. 

Moved the method to Nucleotide sequence and cleaned up around it.